### PR TITLE
Python 3 Support

### DIFF
--- a/pwgen/__init__.py
+++ b/pwgen/__init__.py
@@ -16,8 +16,8 @@ from random import SystemRandom
 choice = SystemRandom().choice
 randint = SystemRandom().randint
 
-LowercaseLetters = string.lowercase
-UpperCase = string.uppercase
+LowercaseLetters = string.ascii_lowercase
+UpperCase = string.ascii_uppercase
 Digits = string.digits
 Symbols = string.punctuation
 


### PR DESCRIPTION
Just had to prefix the string functions with 'ascii_' and now both Python 2 and 3 work as expected.
